### PR TITLE
Support error and warning color

### DIFF
--- a/plugin/lightline-hybrid.vim
+++ b/plugin/lightline-hybrid.vim
@@ -67,6 +67,11 @@ else
 				\ [s:mono0, s:mono4, s:c_mono0, s:c_mono4]]
 endif
 
+let s:p.normal.error = [
+			\ [s:mono0, s:red, s:c_mono0, s:c_red]]
+let s:p.normal.warning = [
+			\ [s:mono0, s:orange, s:c_mono0, s:c_orange]]
+
 let s:p.inactive.middle = [
 			\ [s:mono4, s:mono2, s:c_mono4, s:c_mono2]]
 let s:p.inactive.right = [


### PR DESCRIPTION
`p.normal.error` and `p.normal.warning` are supported in lightline's colorschemes.

https://github.com/itchyny/lightline.vim/blob/master/autoload/lightline/colorscheme/wombat.vim#L37-L38